### PR TITLE
traces and examples for snapshot not working with new firerunner

### DIFF
--- a/bins/firerunner/main.rs
+++ b/bins/firerunner/main.rs
@@ -250,8 +250,10 @@ fn main() {
         }
     };
 
-    //TODO: Optionally add a logger
+    eprintln!("Ready to start vm....");
+    std::thread::sleep(std::time::Duration::from_secs(2));
 
+    //TODO: Optionally add a logger
 
     // Launch vm
     let ret = match vmm.start_instance() {
@@ -261,9 +263,9 @@ fn main() {
             std::process::exit(1);
         }
     };
-
-
-
+    eprintln!("{:?}", ret);
+    std::thread::sleep(std::time::Duration::from_secs(2));
+    
     // wait for ready notification from vm
     let ret = match vm.recv_status() {
         Ok(d) => d,
@@ -274,6 +276,7 @@ fn main() {
             std::process::exit(1);
         }
     };
+    eprintln!("ready: {:?}", ret);
 
     // notify snapfaas that the vm is ready
     io::stdout().write_all(READY).expect("stdout");

--- a/fc_wrapper_test.sh
+++ b/fc_wrapper_test.sh
@@ -1,0 +1,6 @@
+#echo "No snapshot"
+#echo "loremjs"
+#cat resources/loremjs.json | ./target/release/fc_wrapper --id 1 --kernel foo --mem_size 128 --rootfs /etc/snapfaas/resources/runtimefs/nodejs.ext4 --vcpu_count 2 --appfs /etc/snapfaas/resources/appfs/loremjs.ext4 
+#echo ""
+echo "Snapshot"
+./target/release/fc_wrapper --id 1 --kernel /etc/snapfaas/vmlinux --mem_size 128 --rootfs /etc/snapfaas/resources/runtimefs/nodejs.ext4 --vcpu_count 1 --appfs /etc/snapfaas/resources/appfs/loremjs.ext4 --load_dir /etc/snapfaas/resources/snapshots/nodejs-128/

--- a/src/vm.rs
+++ b/src/vm.rs
@@ -133,7 +133,10 @@ impl Vm {
                             67 =>Error::RootfsNotExist,
                             68 =>Error::AppfsNotExist,
                             69 =>Error::LoadDirNotExist,
-                            _ => Error::ReadySignal(io::Error::new(io::ErrorKind::InvalidData, code.to_string())),
+                            _ => {
+                                println!("VM process exit?: {:?}", vm_process.wait());
+                                Error::ReadySignal(io::Error::new(io::ErrorKind::InvalidData, code.to_string()))
+                            }
                         };
                         return Err(err);
                     }


### PR DESCRIPTION
This pull request summarizes my investigation of snapshot not working with the new firerunner.

**Problem:**
When booting from snapshot KVM_RUN exits with shutdown as soon as when a vcpu starts running.

**How to reproduce:**
Generate snapshot with something like:
```base
./target/release/firerunner --id 42 --kernel /etc/snapfaas/vmlinux --mem_size 128 --rootfs /etc/snapfaas/resources/runtimefs/nodejs.ext4 --appfs /etc/snapfaas/resources/appfs/loremjs.ext4 --vcpu_count 1 --dump_to out/
```
This interface is nearly identical to the previous firerunner.

Then boot a vm from snapshot with `fc_wrapper` -- a simple binary that wraps around `firerunner`. (`fc_wrapper` reads error codes and responses from `firerunner`'s stdout and writes requests with the correct format to `firerunner`'s stdin).
```bash
./target/release/fc_wrapper --id 1 --kernel /etc/snapfaas/vmlinux --mem_size 128 --rootfs /etc/snapfaas/resources/runtimefs/nodejs.ext4 --vcpu_count 1 --appfs /etc/snapfaas/resources/appfs/loremjs.ext4 --load_dir out/
```

**What will we see in trace:**
I added `eprintln!()` in firerunner and firecracker code. firecracker changes are in `princeton-sns/firecracker:branch:snapfaas-snapshot`. If you check out `princeton-sns/snapfaas:branch:snapshot`, the firecracker submodule should automatically point to its `snapfaas-snapshot` branch.

You should see something like this when there's one vcpu:
```bash
[fc] VMM received instance start command
[fc] Start run_emulation
[fc] kvm/src/lib.rs run()
[fc] kvm/src/lib.rs KVM_RUN: 0
[fc] run.exit_reason: 8
[fc] Received a shutdown
VM process exit?: Ok(ExitStatus(ExitStatus(0)))
Vm creation failed due to: ReadySignal(Custom { kind: InvalidData, error: "0" })
```

**The trace shows the following:**
1. firecracker successfully opened `runtime_mem_dump` and  `snapshot.json`.
2. guest memory, vcpu state, and device restoration succeeded in `start_microvm()`
3. `vcpu.run()` and `vcpu.run_emulation()` ran for a single iteration and exited with `VcpuExit::Shutdown`. This subsequently caused the vcpu thread to exit and the vmm thread to exit and the whole process to exit with `FC_EXIT_CODE_OK` which is 0.
4. The last 2 lines of the traces are produced by `fc_wrapper`, basically telling us that the vm exited without sending us a ready signal.

**Suspicion:**
We will definitely need to see some guest and/or kvm logs to see what actually happened. But when capturing guest vm memory to generate a snapshot, do we measure dirty pages of the entire process or just the VM? In the previous firerunner, the child process (the process that the VM runs in) has 3 types of threads: (1). process main thread (2). vmm thread and (3). vcpu thread(s). The main thread does nothing but join on the vmm thread. However, in the new firerunner, the main thread does a lot more. For example, it manages the stdin and stdout of the entire process-- reading requests from stdin and writing responses and error codes to stdout. Could this be causing issues?


