### PR TITLE
Optionally set O_DIRECT for block device files and snapshot memory files

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -502,6 +502,7 @@ dependencies = [
  "futures 0.1.29 (registry+https://github.com/rust-lang/crates.io-index)",
  "glob 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "memory_model 0.1.0",
  "net_util 0.1.0",
  "nix 0.16.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.103 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,6 +38,7 @@ shellexpand = "1.0.0"
 nix = "0.16.0"
 cgroups = "0.1.0"
 vmm = { path = "firecracker/vmm", features = ["vsock"]}
+memory_model = { path = "firecracker/memory_model" }
 fc_util = { path = "firecracker/fc_util" }
 sys_util = { path = "firecracker/sys_util" }
 net_util = { path = "firecracker/net_util" }

--- a/microbenchmark/run.sh
+++ b/microbenchmark/run.sh
@@ -7,6 +7,6 @@ fi
 
 source ./env
 
-run_scripts/run_diff.sh $1 $2
-run_scripts/run_fullapp.sh $1 $2
+#run_scripts/run_diff.sh $1 $2
+#run_scripts/run_fullapp.sh $1 $2
 run_scripts/run_regular.sh $1 $2

--- a/microbenchmark/run_scripts/run_fullapp.sh
+++ b/microbenchmark/run_scripts/run_fullapp.sh
@@ -11,10 +11,37 @@ rounds=$(($1 + $2 - 1))
 
 source ./env
 
-echo 'Starting...'
+echo 'Starting fullapp ondemand...'
+[ ! -d full-app-ondemand-out ] && mkdir full-app-ondemand-out
+for ((i=$startindex; i<=$rounds; i++))
+do
+    echo "Round $i"
+    # drop page cache
+    echo 1 | sudo tee /proc/sys/vm/drop_caches &>/dev/null
+    for runtime in python3 nodejs
+    do
+        for app in $(ls ../snapfaas-images/appfs/$runtime)
+        do
+            echo "- $app-$runtime"
+	    cat ../resources/requests/$app-$runtime.json | head -1 | \
+            taskset -c 0 sudo $MEMBINDIR/fc_wrapper \
+                --vcpu_count 1 \
+                --mem_size 128 \
+                --kernel $KERNEL \
+                --network 'tap0/aa:bb:cc:dd:ff:00' \
+                --firerunner $MEMBINDIR/firerunner \
+                --rootfs $SSDROOTFSDIR/$app-$runtime.ext4 \
+                --load_dir $SSDSNAPSHOTDIR/$app-$runtime \
+                > full-app-ondemand-out/$app-$runtime.$i.txt
+            [ $? -ne 0 ] && echo '!! failed' && exit 1
+        done
+    done
+done
+
+echo 'Starting fullapp eager...'
 # drop page cache
 echo 1 | sudo tee /proc/sys/vm/drop_caches &>/dev/null
-[ ! -d full-app-out ] && mkdir full-app-out
+[ ! -d full-app-eager-out ] && mkdir full-app-eager-out
 for ((i=$startindex; i<=$rounds; i++))
 do
     echo "Round $i"
@@ -32,7 +59,9 @@ do
                 --firerunner $MEMBINDIR/firerunner \
                 --rootfs $SSDROOTFSDIR/$app-$runtime.ext4 \
                 --load_dir $SSDSNAPSHOTDIR/$app-$runtime \
-                > full-app-out/$app-$runtime.$i.txt
+		--copy_base \
+		--odirect_base \
+                > full-app-eager-out/$app-$runtime.$i.txt
             [ $? -ne 0 ] && echo '!! failed' && exit 1
         done
     done

--- a/microbenchmark/run_scripts/run_regular.sh
+++ b/microbenchmark/run_scripts/run_regular.sh
@@ -31,7 +31,7 @@ do
                 --network 'tap0/aa:bb:cc:dd:ff:00' \
                 --firerunner $MEMBINDIR/firerunner \
                 --rootfs $SSDROOTFSDIR/$app-$runtime.ext4 \
-                > regular-out/$app.$i.txt
+                > regular-out/$app-$runtime.$i.txt
             [ $? -ne 0 ] && echo '!! failed' && exit 1
         done
     done

--- a/microbenchmark/setup_scripts/build_binaries.sh
+++ b/microbenchmark/setup_scripts/build_binaries.sh
@@ -1,3 +1,4 @@
 #!/usr/bin/env bash
+source ./env
 echo 'Building fc_wrapper and firerunner...'
 cargo build --release --quiet --target-dir $MOUNTPOINT/bin --bins

--- a/src/controller.rs
+++ b/src/controller.rs
@@ -168,7 +168,7 @@ impl Controller {
                 trace!("Allocating new VM. ID: {:?}, App: {:?}", id, function_config.name);
 
                 #[cfg(not(test))]
-                return Vm::new(&id.to_string(), function_config, _vm_listener, _cid, Some(_network), &self.controller_config.firerunner_path, false)
+                return Vm::new(&id.to_string(), function_config, _vm_listener, _cid, Some(_network), &self.controller_config.firerunner_path, false, None)
                     .map_err(|e| {
                         // Make sure to "unreserve" the resource by incrementing
                         // `Controller::free_mem`

--- a/src/vm.rs
+++ b/src/vm.rs
@@ -29,6 +29,13 @@ pub enum Error {
     NotString(std::string::FromUtf8Error),
 }
 
+pub struct OdirectOption {
+    pub base: bool,
+    pub diff: bool,
+    pub rootfs: bool,
+    pub appfs: bool,
+}
+
 #[derive(Debug)]
 pub struct VmAppConfig {
     pub rootfs: String,
@@ -72,6 +79,7 @@ impl Vm {
         network: Option<&str>,
         firerunner: &str,
         force_exit: bool,
+        odirect: Option<OdirectOption>,
     ) -> Result<(Vm, Vec<Instant>), Error> {
         let mut ts_vec = Vec::with_capacity(10);
         ts_vec.push(Instant::now());
@@ -121,6 +129,22 @@ impl Vm {
             let v: Vec<&str> = network.split('/').collect();
             args.extend_from_slice(&["--tap_name", v[0]]);
             args.extend_from_slice(&["--mac", v[1]]);
+        }
+
+        // odirect
+        if let Some(odirect) = odirect {
+            if odirect.base {
+                args.push("--odirect_base");
+            }
+            if !odirect.diff {
+                args.push("--no_odirect_diff");
+            }
+            if !odirect.rootfs {
+                args.push("--no_odirect_root");
+            }
+            if !odirect.appfs {
+                args.push("--no_odirect_app");
+            }
         }
 
         info!("args: {:?}", args);


### PR DESCRIPTION
By default, `rootfs`, `appfs`, `diff snapshot` are opened with O_DIRECT set.

When using `fc_wrapper`, pass `--no_odirect_rootfs`, `--no_odirect_appfs`, `--no_odirect_diff` to open these files without O_DIRECT and pass `--odirect_base` to open base snapshot memory file with O_DIRECT.

`snapctr` always uses the default setting.