### PR TITLE
Wait for either child exit or vsock connection in VM creation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1281,6 +1281,7 @@ dependencies = [
  "signal-hook",
  "sys_util",
  "time",
+ "tokio",
  "url",
  "vmm",
 ]
@@ -1398,8 +1399,22 @@ dependencies = [
  "memchr",
  "mio",
  "num_cpus",
+ "once_cell",
  "pin-project-lite",
+ "signal-hook-registry",
+ "tokio-macros",
  "winapi",
+]
+
+[[package]]
+name = "tokio-macros"
+version = "1.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c9efc1aba077437943f7515666aa2b882dfabfbfdf89c819ea75a8d6e9eaba5e"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,10 +5,6 @@ authors = ["David H. Liu<hl7@cs.princeton.edu>", "Yue Tan<yuetan@cs.princeton.ed
 edition = "2018"
 
 [[bin]]
-name = "snapctr"
-path = "bins/snapctr/main.rs"
-
-[[bin]]
 name = "firerunner"
 path = "bins/firerunner/main.rs"
 
@@ -51,6 +47,7 @@ signal-hook = "0.1.13"
 crossbeam-channel = "0.4.2"
 futures = "0.1.18"
 glob =  "*"
+tokio = { version = "1.14.0", features = [ "rt", "macros",  "process", "net" ] }
 
 [build-dependencies]
 prost-build = "0.9.0"

--- a/bins/fc_wrapper/main.rs
+++ b/bins/fc_wrapper/main.rs
@@ -225,7 +225,7 @@ fn main() {
     // Launch a vm based on the FunctionConfig value
     let t1 = Instant::now();
     let firerunner = cmd_arguments.value_of("firerunner").unwrap();
-    let (mut vm, ts_vec) = match Vm::new(id, "myapp", &vm_app_config, &vm_listener, CID,
+    let (mut vm, ts_vec) = match Vm::new(id, "myapp", &vm_app_config, vm_listener, CID,
         cmd_arguments.is_present("enable network"), firerunner, cmd_arguments.is_present("force exit"), Some(odirect))
     {
         Ok(vm) => vm,
@@ -252,7 +252,7 @@ fn main() {
             }
             Err(e) => {
                 eprintln!("invalid requests: {:?}", e);
-                vm.shutdown();
+                drop(vm);
                 unlink_unix_sockets();
                 std::process::exit(1);
             }
@@ -294,6 +294,6 @@ fn main() {
 
     // Shutdown the vm and exit
     println!("Shutting down vm...");
-    vm.shutdown();
+    drop(vm);
     unlink_unix_sockets();
 }

--- a/shell.nix
+++ b/shell.nix
@@ -3,5 +3,5 @@
 with pkgs;
 
 mkShell {
-  buildInputs = [ rustup cargo rustc rustfmt protobuf ];
+  buildInputs = [ cargo rustc rustfmt protobuf pkg-config openssl ];
 }


### PR DESCRIPTION
When starting a VM we currently wait for a vsock connection from the VM. However, the VM may die before that happens, in which we want to return early rather than block indefinitely.

This PR accomplishes that using using tokio's select! to block on _either_ vsock connection _or_ the Child exiting during VM creation.
