### PR TITLE
General improvements to `multivm`

### DIFF
--- a/Cargo.nix
+++ b/Cargo.nix
@@ -3578,6 +3578,7 @@ rec {
           { name = "firerunner"; path = "bins/firerunner/main.rs"; }
           { name = "singlevm"; path = "bins/singlevm/main.rs"; }
           { name = "multivm"; path = "bins/multivm/main.rs"; }
+          { name = "sfclient"; path = "bins/sfclient/main.rs"; }
           { name = "sfdb"; path = "bins/sfdb/main.rs"; }
         ];
         src = lib.cleanSourceWith { filter = sourceFilter;  src = ./.; };

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,6 +17,10 @@ name = "multivm"
 path = "bins/multivm/main.rs"
 
 [[bin]]
+name = "sfclient"
+path = "bins/sfclient/main.rs"
+
+[[bin]]
 name = "sfdb"
 path = "bins/sfdb/main.rs"
 

--- a/bins/sfclient/main.rs
+++ b/bins/sfclient/main.rs
@@ -1,0 +1,51 @@
+#[macro_use(crate_version, crate_authors)]
+extern crate clap;
+use clap::{App, Arg};
+use snapfaas::request;
+use std::net::TcpStream;
+use std::io::{Read, stdin};
+
+fn main() -> std::io::Result<()> {
+    let cmd_arguments = App::new("SnapFaaS CLI Client")
+        .version(crate_version!())
+        .author(crate_authors!())
+        .about("Make a request to SnapFaaS")
+        .arg(
+            Arg::with_name("server address")
+                .value_name("[ADDR:]PORT")
+                .long("server")
+                .short("s")
+                .takes_value(true)
+                .required(true)
+                .help("Address on which SnapFaaS is listening for connections"),
+        )
+        .arg(
+            Arg::with_name("function")
+                .value_name("FUNCTION")
+                .long("function")
+                .short("f")
+                .takes_value(true)
+                .required(true)
+                .help("Function name"),
+        )
+        .get_matches();
+
+
+    let addr = cmd_arguments.value_of("server address").unwrap();
+    let function = cmd_arguments.value_of("function").unwrap().to_string();
+    let mut input = Vec::new();
+    stdin().read_to_end(&mut input)?;
+    let payload = serde_json::from_slice(&input)?;
+    let request = request::Request {
+        user_id: 0,
+        function,
+        payload,
+    };
+
+    let mut connection = TcpStream::connect(addr)?;
+    request::write_u8(&request.to_vec(), &mut connection)?;
+    input = request::read_u8(&mut connection)?;
+    let response: request::Response = serde_json::from_slice(&input)?;
+    println!("{:?}", response);
+    Ok(())
+}

--- a/src/configs.rs
+++ b/src/configs.rs
@@ -40,13 +40,14 @@ impl ResourceManagerConfig {
             // populate a ResourceManagerConfig struct from the yaml file
             if let Ok(f) = File::open(config_url.path()) {
                 let config: serde_yaml::Result<ResourceManagerConfig> = serde_yaml::from_reader(f);
-                if let Ok(mut config) = config {
-                    ResourceManagerConfig::convert_to_url(&mut config);
-                    ResourceManagerConfig::build_full_path_fs_images(&mut config);
-                    debug!("ResourceManager config: {:?}", config);
-                    config
-                } else {
-                    panic!("Invalid YAML file");
+                match config {
+                    Ok(mut config) => {
+                        ResourceManagerConfig::convert_to_url(&mut config);
+                        ResourceManagerConfig::build_full_path_fs_images(&mut config);
+                        debug!("ResourceManager config: {:?}", config);
+                        config
+                    },
+                    Err(e) => panic!("Invalid YAML file {:?}", e)
                 }
             } else {
                 panic!("Invalid local path to config file");

--- a/src/request.rs
+++ b/src/request.rs
@@ -42,10 +42,6 @@ impl Request {
 
 }
 
-pub fn parse_json(json: &str) -> Result<Request, serde_json::Error> {
-    serde_json::from_str(json)
-}
-
 /// Given a [u8], parse it to a Requst value
 pub fn parse_u8_request(buf: Vec<u8>) -> Result<Request, serde_json::Error> {
     serde_json::from_slice(&buf)

--- a/src/worker.rs
+++ b/src/worker.rs
@@ -22,7 +22,7 @@ use crate::resource_manager;
 
 #[derive(Debug)]
 pub struct Worker {
-    pub thread: Option<JoinHandle<()>>,
+    pub thread: JoinHandle<()>,
 }
 
 impl Worker {
@@ -121,11 +121,11 @@ impl Worker {
             }
         });
 
-        Worker { thread: Some(handle) }
+        Worker { thread: handle }
     }
 
-    pub fn take(&mut self) -> Option<JoinHandle<()>> {
-        self.thread.take()
+    pub fn join(self) -> std::thread::Result<()> {
+        self.thread.join()
     }
 }
 


### PR DESCRIPTION
This PR fixes one issue and adds a small utility for interacting with the multivm.

* Instead of busy-looping in the `gateway` module, which consumes 100% of a CPU-core when everything is otherwise idle, convert the gateway to a threaded server.
* Add a utility, `sfclient`, to send requests to `multivm` from the command-line. Useful at least for testing.
* Print out YAML parse error from `multivm` if reading the config file fails

The last couple commits include some nit cleanups that i accidentally committed such that they can't be easily separated, but they are not major features.