### PR TITLE
Create LMDB environment once globally

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1285,6 +1285,7 @@ dependencies = [
  "futures",
  "glob",
  "labeled",
+ "lazy_static",
  "lmdb-rkv",
  "log",
  "memory_model",

--- a/Cargo.nix
+++ b/Cargo.nix
@@ -3631,6 +3631,10 @@ rec {
             packageId = "labeled";
           }
           {
+            name = "lazy_static";
+            packageId = "lazy_static";
+          }
+          {
             name = "lmdb-rkv";
             packageId = "lmdb-rkv";
           }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -49,6 +49,7 @@ crossbeam-channel = "0.4.2"
 futures = "0.1.18"
 glob =  "*"
 tokio = { version = "1.14.0", features = [ "rt", "macros",  "process", "net" ] }
+lazy_static = "1.4.0"
 
 [build-dependencies]
 prost-build = "0.9.0"

--- a/src/vm.rs
+++ b/src/vm.rs
@@ -16,7 +16,7 @@ use serde_json::Value;
 use crate::configs::FunctionConfig;
 use crate::message::Message;
 use crate::syscalls;
-use crate::request::{Request, RequestStatus, Response};
+use crate::request::{Request, RequestStatus};
 
 const MACPREFIX: &str = "AA:BB:CC:DD";
 const GITHUB_REST_ENDPOINT: &str = "https://api.github.com";
@@ -26,6 +26,13 @@ const USER_AGENT: &str = "snapfaas";
 
 use labeled::dclabel::{Clause, Component, DCLabel};
 use labeled::Label;
+
+lazy_static::lazy_static! {
+    static ref DBENV: lmdb::Environment = lmdb::Environment::new()
+        .set_map_size(4096 * 1024 * 1024)
+        .open(std::path::Path::new("storage"))
+        .unwrap();
+}
 
 #[derive(Debug)]
 pub enum Error {
@@ -306,17 +313,22 @@ impl Vm {
         }
     }
 
-    fn send_req(&self, invoke: syscalls::Invoke) -> Response {
+    fn send_req(&self, invoke: syscalls::Invoke) -> bool {
         let (tx, rx) = mpsc::channel();
-        self.handle.as_ref().unwrap().invoke_handle.as_ref().unwrap().send(Message::Request(
-            Request {
-                user_id: 0,
-                function: invoke.function,
-                payload: serde_json::Value::String(invoke.payload),
-            },
-            tx, 
-        )).expect("Failed to send request");
-        rx.recv().expect("Failed to receive request response")
+        if let Some(invoke_handle) = self.handle.as_ref().and_then(|h| h.invoke_handle.as_ref()) {
+            invoke_handle.send(Message::Request(
+                Request {
+                    user_id: 0,
+                    function: invoke.function,
+                    payload: serde_json::from_str(invoke.payload.as_str()).expect("json"),
+                },
+                tx,
+            )).expect("Failed to send request");
+            rx.recv().expect("Failed to receive request response").status == RequestStatus::SentToVM
+        } else {
+            debug!("No invoke handle, ignoring invoke syscall. {:?}", invoke);
+            false
+        }
     }
 
     pub fn process_syscall(&mut self) -> Result<String, Error> {
@@ -326,11 +338,8 @@ impl Vm {
         use syscalls::syscall::Syscall as SC;
         use syscalls::Syscall;
 
-        let dbenv = lmdb::Environment::new()
-            .set_map_size(4096 * 1024 * 1024)
-            .open(std::path::Path::new("storage"))
-            .unwrap();
-        let default_db = dbenv.open_db(None).unwrap();
+        
+        let default_db = DBENV.open_db(None).unwrap();
 
         loop {
             let buf = {
@@ -347,17 +356,11 @@ impl Vm {
                     return Ok(r.payload);
                 }
                 Some(SC::Invoke(invoke)) => {
-                    if self.handle.as_ref().unwrap().invoke_handle.is_none() {
-                        debug!("No invoke handle, ignoring invoke syscall.");
-                        continue;
-                    }
-                    let success = self.send_req(invoke).status == RequestStatus::SentToVM;
-                    let result = syscalls::InvokeResponse { success }.encode_to_vec();
-
-                    self.send_into_vm(result)?;
+                    let result = syscalls::InvokeResponse { send_req(invoke) };
+                    self.send_into_vm(result.encode_to_vec())?;
                 }
                 Some(SC::ReadKey(rk)) => {
-                    let txn = dbenv.begin_ro_txn().unwrap();
+                    let txn = DBENV.begin_ro_txn().unwrap();
                     let result = syscalls::ReadKeyResponse {
                         value: txn.get(default_db, &rk.key).ok().map(Vec::from),
                     }
@@ -367,7 +370,7 @@ impl Vm {
                     self.send_into_vm(result)?;
                 },
                 Some(SC::WriteKey(wk)) => {
-                    let mut txn = dbenv.begin_rw_txn().unwrap();
+                    let mut txn = DBENV.begin_rw_txn().unwrap();
                     let result = syscalls::WriteKeyResponse {
                         success: txn
                             .put(default_db, &wk.key, &wk.value, WriteFlags::empty())

--- a/src/worker.rs
+++ b/src/worker.rs
@@ -78,10 +78,10 @@ impl Worker {
                                     // newly allocated VM is returned, launch it first
                                     if let Err(e) = vm.launch(Some(func_req_sender.clone()), vm_listener_dup, cid, false, None) {
                                         handle_vm_error(e, &mut stat);                                    
-                                        rsp_sender.send(Response {
+                                        let _ = rsp_sender.send(Response {
                                             user_id: req.user_id,
                                             status: RequestStatus::LaunchFailed,
-                                        }).expect("Failed to write response"); 
+                                        });
                                         // a VM launched or not occupies system resources, we need
                                         // to put back the resources assigned to this VM.
                                         vm_req_sender.send(Message::DeleteVm(vm)).expect("Failed to send DeleteVm request");
@@ -90,10 +90,10 @@ impl Worker {
                                 }
 
                                 debug!("VM is launched");
-                                rsp_sender.send(Response {
+                                let _ = rsp_sender.send(Response {
                                     user_id: req.user_id,
                                     status: RequestStatus::SentToVM,
-                                }).expect("Failed to write response");
+                                });
 
                                 match process_req(req, &mut vm, &mut stat) {
                                     Ok(rsp) => {
@@ -107,10 +107,10 @@ impl Worker {
                             },
                             Err(e) => {
                                 let status = handle_resource_manager_error(e, &mut stat, &req.function);
-                                rsp_sender.send(Response {
+                                let _ = rsp_sender.send(Response {
                                     user_id: req.user_id,
                                     status,
-                                }).expect("Failed to write response");
+                                });
                             }
                         }
                     }


### PR DESCRIPTION
LMDB environment should not be created more than once per process,
instead should be shared across threads.

See http://www.lmdb.tech/doc/starting.html#thrproc

This PR uses `lazy_static` to initialize the LMDB environment globally in `vm.rs` as a static variable.