### PR TITLE
Some general cleanup

### DIFF
--- a/bins/sfclient/main.rs
+++ b/bins/sfclient/main.rs
@@ -37,7 +37,6 @@ fn main() -> std::io::Result<()> {
     stdin().read_to_end(&mut input)?;
     let payload = serde_json::from_slice(&input)?;
     let request = request::Request {
-        user_id: 0,
         function,
         payload,
     };

--- a/frontends/webhook/Cargo.lock
+++ b/frontends/webhook/Cargo.lock
@@ -29,6 +29,7 @@ checksum = "8b26702f315f53b6071259e15dd9d64528213b44d61de1ec926eca7715d62203"
 [[package]]
 name = "arch"
 version = "0.1.0"
+source = "git+git://github.com/princeton-sns/firecracker?rev=f2559c1dac7c4b51b5e8b98ce00ac5bcc5d1865d#f2559c1dac7c4b51b5e8b98ce00ac5bcc5d1865d"
 dependencies = [
  "arch_gen",
  "byteorder",
@@ -41,6 +42,7 @@ dependencies = [
 [[package]]
 name = "arch_gen"
 version = "0.1.0"
+source = "git+git://github.com/princeton-sns/firecracker?rev=f2559c1dac7c4b51b5e8b98ce00ac5bcc5d1865d#f2559c1dac7c4b51b5e8b98ce00ac5bcc5d1865d"
 
 [[package]]
 name = "atty"
@@ -126,7 +128,7 @@ dependencies = [
  "num-integer",
  "num-traits",
  "serde",
- "time 0.1.43",
+ "time",
  "winapi",
 ]
 
@@ -164,6 +166,7 @@ checksum = "5827cebf4670468b8772dd191856768aedcb1b0278a04f989f7766351917b9dc"
 [[package]]
 name = "cpuid"
 version = "0.1.0"
+source = "git+git://github.com/princeton-sns/firecracker?rev=f2559c1dac7c4b51b5e8b98ce00ac5bcc5d1865d#f2559c1dac7c4b51b5e8b98ce00ac5bcc5d1865d"
 dependencies = [
  "kvm",
  "kvm-bindings",
@@ -215,6 +218,7 @@ dependencies = [
 [[package]]
 name = "devices"
 version = "0.1.0"
+source = "git+git://github.com/princeton-sns/firecracker?rev=f2559c1dac7c4b51b5e8b98ce00ac5bcc5d1865d#f2559c1dac7c4b51b5e8b98ce00ac5bcc5d1865d"
 dependencies = [
  "byteorder",
  "dumbo",
@@ -234,6 +238,7 @@ dependencies = [
 [[package]]
 name = "dumbo"
 version = "0.1.0"
+source = "git+git://github.com/princeton-sns/firecracker?rev=f2559c1dac7c4b51b5e8b98ce00ac5bcc5d1865d#f2559c1dac7c4b51b5e8b98ce00ac5bcc5d1865d"
 dependencies = [
  "bitflags",
  "byteorder",
@@ -284,6 +289,7 @@ dependencies = [
 [[package]]
 name = "fc_util"
 version = "0.1.0"
+source = "git+git://github.com/princeton-sns/firecracker?rev=f2559c1dac7c4b51b5e8b98ce00ac5bcc5d1865d#f2559c1dac7c4b51b5e8b98ce00ac5bcc5d1865d"
 dependencies = [
  "libc",
 ]
@@ -605,6 +611,7 @@ dependencies = [
 [[package]]
 name = "kernel"
 version = "0.1.0"
+source = "git+git://github.com/princeton-sns/firecracker?rev=f2559c1dac7c4b51b5e8b98ce00ac5bcc5d1865d#f2559c1dac7c4b51b5e8b98ce00ac5bcc5d1865d"
 dependencies = [
  "memory_model",
  "sys_util",
@@ -613,6 +620,7 @@ dependencies = [
 [[package]]
 name = "kvm"
 version = "0.1.0"
+source = "git+git://github.com/princeton-sns/firecracker?rev=f2559c1dac7c4b51b5e8b98ce00ac5bcc5d1865d#f2559c1dac7c4b51b5e8b98ce00ac5bcc5d1865d"
 dependencies = [
  "kvm-bindings",
  "libc",
@@ -685,6 +693,7 @@ dependencies = [
 [[package]]
 name = "logger"
 version = "0.1.0"
+source = "git+git://github.com/princeton-sns/firecracker?rev=f2559c1dac7c4b51b5e8b98ce00ac5bcc5d1865d#f2559c1dac7c4b51b5e8b98ce00ac5bcc5d1865d"
 dependencies = [
  "chrono",
  "lazy_static",
@@ -693,7 +702,7 @@ dependencies = [
  "serde",
  "serde_derive",
  "serde_json",
- "time 0.3.5",
+ "time",
 ]
 
 [[package]]
@@ -726,6 +735,7 @@ dependencies = [
 [[package]]
 name = "memory_model"
 version = "0.1.0"
+source = "git+git://github.com/princeton-sns/firecracker?rev=f2559c1dac7c4b51b5e8b98ce00ac5bcc5d1865d#f2559c1dac7c4b51b5e8b98ce00ac5bcc5d1865d"
 dependencies = [
  "libc",
  "serde",
@@ -735,6 +745,7 @@ dependencies = [
 [[package]]
 name = "micro_http"
 version = "0.1.0"
+source = "git+git://github.com/princeton-sns/firecracker?rev=f2559c1dac7c4b51b5e8b98ce00ac5bcc5d1865d#f2559c1dac7c4b51b5e8b98ce00ac5bcc5d1865d"
 
 [[package]]
 name = "mime"
@@ -767,6 +778,7 @@ dependencies = [
 [[package]]
 name = "mmds"
 version = "0.1.0"
+source = "git+git://github.com/princeton-sns/firecracker?rev=f2559c1dac7c4b51b5e8b98ce00ac5bcc5d1865d#f2559c1dac7c4b51b5e8b98ce00ac5bcc5d1865d"
 dependencies = [
  "json-patch",
  "lazy_static",
@@ -801,6 +813,7 @@ dependencies = [
 [[package]]
 name = "net_gen"
 version = "0.1.0"
+source = "git+git://github.com/princeton-sns/firecracker?rev=f2559c1dac7c4b51b5e8b98ce00ac5bcc5d1865d#f2559c1dac7c4b51b5e8b98ce00ac5bcc5d1865d"
 dependencies = [
  "sys_util",
 ]
@@ -808,6 +821,7 @@ dependencies = [
 [[package]]
 name = "net_util"
 version = "0.1.0"
+source = "git+git://github.com/princeton-sns/firecracker?rev=f2559c1dac7c4b51b5e8b98ce00ac5bcc5d1865d#f2559c1dac7c4b51b5e8b98ce00ac5bcc5d1865d"
 dependencies = [
  "libc",
  "net_gen",
@@ -1077,12 +1091,13 @@ dependencies = [
 [[package]]
 name = "rate_limiter"
 version = "0.1.0"
+source = "git+git://github.com/princeton-sns/firecracker?rev=f2559c1dac7c4b51b5e8b98ce00ac5bcc5d1865d#f2559c1dac7c4b51b5e8b98ce00ac5bcc5d1865d"
 dependencies = [
  "libc",
  "logger",
  "serde",
  "serde_derive",
- "time 0.1.43",
+ "time",
  "timerfd",
 ]
 
@@ -1199,6 +1214,7 @@ dependencies = [
 [[package]]
 name = "seccomp"
 version = "0.1.0"
+source = "git+git://github.com/princeton-sns/firecracker?rev=f2559c1dac7c4b51b5e8b98ce00ac5bcc5d1865d#f2559c1dac7c4b51b5e8b98ce00ac5bcc5d1865d"
 dependencies = [
  "libc",
 ]
@@ -1325,6 +1341,7 @@ checksum = "9def91fd1e018fe007022791f865d0ccc9b3a0d5001e01aabb8b40e46000afb5"
 name = "snapfaas"
 version = "0.1.0"
 dependencies = [
+ "byteorder",
  "bytes",
  "cgroups",
  "clap",
@@ -1335,6 +1352,7 @@ dependencies = [
  "futures",
  "glob",
  "labeled",
+ "lazy_static",
  "lmdb-rkv",
  "log",
  "memory_model",
@@ -1347,7 +1365,7 @@ dependencies = [
  "serde_yaml",
  "signal-hook",
  "sys_util",
- "time 0.1.43",
+ "time",
  "tokio",
  "url",
  "vmm",
@@ -1400,6 +1418,7 @@ dependencies = [
 [[package]]
 name = "sys_util"
 version = "0.1.0"
+source = "git+git://github.com/princeton-sns/firecracker?rev=f2559c1dac7c4b51b5e8b98ce00ac5bcc5d1865d#f2559c1dac7c4b51b5e8b98ce00ac5bcc5d1865d"
 dependencies = [
  "libc",
 ]
@@ -1444,15 +1463,6 @@ checksum = "ca8a50ef2360fbd1eeb0ecd46795a87a19024eb4b53c5dc916ca1fd95fe62438"
 dependencies = [
  "libc",
  "winapi",
-]
-
-[[package]]
-name = "time"
-version = "0.3.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41effe7cfa8af36f439fac33861b66b049edc6f9a32331e2312660529c1c24ad"
-dependencies = [
- "libc",
 ]
 
 [[package]]
@@ -1645,10 +1655,12 @@ checksum = "f1bddf1187be692e79c5ffeab891132dfb0f236ed36a43c7ed39f1165ee20191"
 [[package]]
 name = "virtio_gen"
 version = "0.1.0"
+source = "git+git://github.com/princeton-sns/firecracker?rev=f2559c1dac7c4b51b5e8b98ce00ac5bcc5d1865d#f2559c1dac7c4b51b5e8b98ce00ac5bcc5d1865d"
 
 [[package]]
 name = "vmm"
 version = "0.1.0"
+source = "git+git://github.com/princeton-sns/firecracker?rev=f2559c1dac7c4b51b5e8b98ce00ac5bcc5d1865d#f2559c1dac7c4b51b5e8b98ce00ac5bcc5d1865d"
 dependencies = [
  "arch",
  "byteorder",
@@ -1672,7 +1684,7 @@ dependencies = [
  "serde_derive",
  "serde_json",
  "sys_util",
- "time 0.3.5",
+ "time",
  "timerfd",
 ]
 

--- a/frontends/webhook/src/main.rs
+++ b/frontends/webhook/src/main.rs
@@ -37,9 +37,11 @@ fn main() -> Result<(), std::io::Error> {
         )
         .get_matches();
 
-    let app = app::App::new(matches.value_of("app config").unwrap());
+    let app = app::App::new(
+        matches.value_of("app config").unwrap(),
+        matches.value_of("snapfaas address").unwrap().to_string()
+    );
     let server = server::Server::new(
-        matches.value_of("snapfaas address").unwrap().to_string(),
         matches.value_of("listen").unwrap(),
         app
     );

--- a/frontends/webhook/src/main.rs
+++ b/frontends/webhook/src/main.rs
@@ -1,3 +1,4 @@
+use std::net::TcpListener;
 use clap::{App, Arg};
 
 mod app;
@@ -41,8 +42,10 @@ fn main() -> Result<(), std::io::Error> {
         matches.value_of("app config").unwrap(),
         matches.value_of("snapfaas address").unwrap().to_string()
     );
+    let listen_addr = matches.value_of("listen").unwrap();
+    let listener = TcpListener::bind(listen_addr).unwrap();
     let server = server::Server::new(
-        matches.value_of("listen").unwrap(),
+        listener,
         app
     );
     server.run()

--- a/src/gateway.rs
+++ b/src/gateway.rs
@@ -47,7 +47,6 @@ impl HTTPGateway {
                                     let (tx, rx) = channel::<request::Response>();
                                     let _ = requests.send((req, tx));
                                     if let Ok(response) = rx.recv() {
-                                        println!("{:?}", response);
                                         if let Err(e) = request::write_u8(&response.to_vec(), &mut stream) {
                                             error!("Failed to respond to TCP client at {:?}: {:?}", stream.peer_addr(), e);
                                         };

--- a/src/request.rs
+++ b/src/request.rs
@@ -13,7 +13,6 @@ pub enum RequestStatus {
                 
 #[derive(Debug, Serialize, Deserialize)]
 pub struct Response {
-    pub user_id: u64,
     pub status: RequestStatus,
 }
 
@@ -25,7 +24,6 @@ impl Response {
 
 #[derive(Debug, Serialize, Deserialize)]
 pub struct Request {
-    pub user_id: u64,
     pub function: String,
     pub payload: Value,
 }

--- a/src/vm.rs
+++ b/src/vm.rs
@@ -318,7 +318,6 @@ impl Vm {
             let (tx, _) = mpsc::channel();
             invoke_handle.send(Message::Request(
                 Request {
-                    user_id: 0,
                     function: invoke.function,
                     payload: serde_json::from_str(invoke.payload.as_str()).expect("json"),
                 },

--- a/src/vm.rs
+++ b/src/vm.rs
@@ -63,6 +63,9 @@ struct VmHandle {
     conn: UnixStream,
     //currently every VM instance opens a connection to the REST server
     rest_client: reqwest::blocking::Client,
+    #[allow(dead_code)]
+    // This field is never used, but we need to it make sure the Child isn't dropped and, thus,
+    // killed, before the VmHandle is dropped.
     vm_process: Child,
     // None when VM is created from single-VM launcher
     invoke_handle: Option<Sender<Message>>,

--- a/src/worker.rs
+++ b/src/worker.rs
@@ -79,7 +79,6 @@ impl Worker {
                                     if let Err(e) = vm.launch(Some(func_req_sender.clone()), vm_listener_dup, cid, false, None) {
                                         handle_vm_error(e, &mut stat);                                    
                                         let _ = rsp_sender.send(Response {
-                                            user_id: req.user_id,
                                             status: RequestStatus::LaunchFailed,
                                         });
                                         // a VM launched or not occupies system resources, we need
@@ -91,7 +90,6 @@ impl Worker {
 
                                 debug!("VM is launched");
                                 let _ = rsp_sender.send(Response {
-                                    user_id: req.user_id,
                                     status: RequestStatus::SentToVM,
                                 });
 
@@ -108,7 +106,6 @@ impl Worker {
                             Err(e) => {
                                 let status = handle_resource_manager_error(e, &mut stat, &req.function);
                                 let _ = rsp_sender.send(Response {
-                                    user_id: req.user_id,
                                     status,
                                 });
                             }


### PR DESCRIPTION
This PR includes more cleanup in a few parts of the code.

* Removes the unused `user_id` field from the `Request` type for now
* Suppresses warnings for a necessary unused field in snapfaas (which now compiles without warnings)
* Moves the webhook frontend's snapfaas connection to the App module, shared via a Mutex. This should probably be replaced by a connection pool (e.g. r2d2), but we definitely don't want to create a new snapfaas connection per client-connection, and almost certainly want the connection logic in the app module, not the server module.