### PR TITLE
log request copies & timestamps at gateway/vmm

### DIFF
--- a/snapfaas/bins/multivm/main.rs
+++ b/snapfaas/bins/multivm/main.rs
@@ -79,11 +79,11 @@ fn main() {
     if let Some(l) = matches.value_of("listen address") {
         let gateway = gateway::HTTPGateway::listen(l);
 
-        for (request, response_tx) in gateway {
+        for (request, response_tx, timestamps) in gateway {
             // Return when a VM acquisition succeeds or fails
             // but before a VM launches (if it is newly allocated)
             // and execute the request.
-            request_sender.send(Message::Request(request, response_tx)).expect("Failed to send request");
+            request_sender.send(Message::Request((request, response_tx, timestamps))).expect("Failed to send request");
         }
     }
 }

--- a/snapfaas/src/message.rs
+++ b/snapfaas/src/message.rs
@@ -3,11 +3,14 @@ use std::sync::mpsc::Sender;
 use crate::request::{Request, Response};
 use crate::vm::Vm;
 use crate::resource_manager;
+use crate::metrics::RequestTimestamps;
+
+pub type RequestInfo = (Request, Sender<Response>, RequestTimestamps);
 
 #[derive(Debug)]
 pub enum Message {
     Shutdown,
-    Request(Request, Sender<Response>),
+    Request(RequestInfo),
     GetVm(String, Sender<Result<Vm, resource_manager::Error>>),
     ReleaseVm(Vm),
     DeleteVm(Vm),

--- a/snapfaas/src/metrics.rs
+++ b/snapfaas/src/metrics.rs
@@ -7,9 +7,15 @@ use log::error;
 use serde_json;
 use serde::Serialize;
 
+use crate::request::Request;
+
 #[derive(Default, Debug, Serialize)]
 pub struct RequestTimestamps {
-    /// request arrival time
+    /// time a request arrives at the gateway
+    pub at_gateway: u64,
+    /// time a request arrives at the VMM invoke handler
+    pub at_vmm: u64,
+    /// time a request arrives at a worker
     pub arrived: u64,
     /// resource allocation completion time, 0 if resource exhaution
     pub allocated: u64,
@@ -17,6 +23,8 @@ pub struct RequestTimestamps {
     pub launched: u64,
     /// response returned time, 0 if execution fails
     pub completed: u64,
+    /// request in bytes
+    pub request: Request,
 }
 
 impl RequestTimestamps {

--- a/snapfaas/src/request.rs
+++ b/snapfaas/src/request.rs
@@ -22,7 +22,7 @@ impl Response {
     }
 }
 
-#[derive(Debug, Serialize, Deserialize)]
+#[derive(Debug, Serialize, Deserialize, Clone, Default)]
 pub struct Request {
     pub function: String,
     pub payload: Value,

--- a/snapfaas/src/worker.rs
+++ b/snapfaas/src/worker.rs
@@ -60,14 +60,10 @@ impl Worker {
                         stat.flush();
                         return;
                     }
-                    Message::Request(req, rsp_sender) => {
+                    Message::Request((req, rsp_sender, mut tsps)) => {
                         debug!("processing request to function {}", &req.function);
                         
-                        use metrics::RequestTimestamps;
-                        let mut tsps = RequestTimestamps {
-                            arrived: precise_time_ns(),
-                            ..Default::default()
-                        };
+                        tsps.arrived = precise_time_ns();
 
                         let function_name = req.function.clone();
                         let (tx, rx) = mpsc::channel();


### PR DESCRIPTION
In addition to the existing four timestamps, for each request, log down a copy of the request and timestamps when it arrives at the gateway or at the VMM invoke handler.