### PR TITLE
Add `sffs` binary

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -877,7 +877,7 @@ dependencies = [
 [[package]]
 name = "labeled"
 version = "0.1.0"
-source = "git+https://github.com/alevy/labeled#98caa38bd59c23be0ab10574286858860d06000c"
+source = "git+https://github.com/tan-yue/labeled?rev=8d9fb2069e1ac7eb111f05d657af4427db600219#8d9fb2069e1ac7eb111f05d657af4427db600219"
 dependencies = [
  "serde",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1781,6 +1781,7 @@ dependencies = [
  "net_util",
  "prost",
  "prost-build",
+ "rand",
  "reqwest",
  "serde",
  "serde_json",

--- a/snapfaas/Cargo.toml
+++ b/snapfaas/Cargo.toml
@@ -24,12 +24,16 @@ path = "bins/sfclient/main.rs"
 name = "sfdb"
 path = "bins/sfdb/main.rs"
 
+[[bin]]
+name = "sffs"
+path = "bins/sffs/main.rs"
+
 [lib]
 
 [dependencies]
 ctrlc = "^3.2.0"
 reqwest = { version = "0.11", features = ["blocking"] }
-labeled = { git = "https://github.com/alevy/labeled" }
+labeled = { git = "https://github.com/tan-yue/labeled", rev = "8d9fb2069e1ac7eb111f05d657af4427db600219" }
 bytes = "1.1.0"
 byteorder = "1.2.1"
 prost = "0.9.0"

--- a/snapfaas/Cargo.toml
+++ b/snapfaas/Cargo.toml
@@ -31,6 +31,7 @@ path = "bins/sffs/main.rs"
 [lib]
 
 [dependencies]
+rand = "^0.8.5"
 ctrlc = "^3.2.0"
 reqwest = { version = "0.11", features = ["blocking"] }
 labeled = { git = "https://github.com/tan-yue/labeled", rev = "8d9fb2069e1ac7eb111f05d657af4427db600219" }

--- a/snapfaas/bins/README.md
+++ b/snapfaas/bins/README.md
@@ -1,63 +1,7 @@
-# snapctr
-
-Start SnapFaaS by running snapctr--the SnapFaaS controller. It starts a gateway
-for accepting requests and a pool of worker threads for handling requests. The
-gateway either waits for requests on a port (HTTPGateway) or reads requests
-from a file (FileGateway). Requests are represented as JSON strings. See
-`resources/example_requests.json` for examples.
-
-The gateway takes requests as input and output a `(Request, Channel)` tuple.
-`Request` is the data structure that represents a function invocation request.
-`Channel` is the response channel. This is a client TCP connetion with
-`HTTPGateway` and a `Sender` to a single response serializer thread with
-`FileGateway`.
-
-`snapctr` then takes the `(Request, Channel)` tuple and forward it to the
-worker pool. The worker pool consists of a pool of worker threads that are
-initialized and launched before the gateway starts accepting requests.  Pool
-size is `total memory/128`, where 128(MB) is the smallest VM size we support.
-
-All threads in the worker pool share the receiver end of a MPSC channel
-protected by a mutex (i.e., `Arc<Mutex<Receiver>>`) and the controller holds the
-sender end. All worker threads try to grab the lock on the receiver and then
-try to receive. Combining a MPSC channel with a mutex makes it simple to
-guarantee that all worker threads hang waiting for requests (not busy waiting),
-only one worker can receive at any given time and immediately after a worker
-finishes receiving, another worker can start receiving. See `Worker::new()`
-for more details.
-
-Once a worker receives a `(Request, Channel)` tuple, it tries to acquire a VM
-with the requested function loaded, forward it the request, wait for the VM to
-finish processing the request and respond, and finally send the response back
-to the client through the `Channel`.
-
-SnapFaaS uses Firecracker VMs and run them in processes separate from the
-controller. After processing a request, a VM does not shutdown. Instead it
-stays idle waiting for another request. Note that each VM in SnapFaaS has only
-a single function loaded. Therefore each VM can only handle a single type of
-requests.
-
-Worker threads (running inside the controller) are responsible for acquiring
-VMs to handle requests. To acquire a VM, a worker first tries to find an idle
-VM capable of handling the request. Such a VM needs to have the requested
-function loaded and is currently not processing another request. If the worker
-cannot find an suitable idle VM, it then tries to launch a VM with the right
-function loaded. It does this by checking if there's enough memory to launch a
-VM with the target function (different functions require VMs with different
-amount of memory) and then spawning a `firerunner` process with the right input
-parameters. If there's not enough memory left, the worker will try to kill idle
-VMs of other functions to free spaces. It first checks whether there's enough
-idle memory, if once freed, to launch its desired VM. If yes, it then kills
-those VMs and then launch its VM. If no, it fails the request and returns an
-error to client, indicating resource exhaustion.
-
-See `snapctr --help` for more details.
-
-# firerunner
-
-`firerunner` is a lightweight wrapper for Firecracker VMM. `snapctr` uses it to
-launch new VMs with specified functions loaded. We can also run `firerunner`
-independently to launch standalone VMs that are not managed by `snapctr`.
-
-See `firerunner --help` for more details.
-
+# List of Binaries 
+1. multivm: a FaaS backend server that runs multiple functions and receives requests from TCP connections.
+2. singlevm: a tool that runs a single function and receives line-delimited JSON requests from the stdin. 
+3. firerunner: a customized virtual machine manager based on firecracker that `multivm` and `singlevm` fork and run in a child process.
+4. sfdb: a tool that injects key-value pairs into the specified lmdb database.
+5. sfclient: a tool that sends requests over a TCP connection to `multivm`.
+6. sffs: a tool that interacts with the labeled file system atop a lmdb database.

--- a/snapfaas/bins/sffs/main.rs
+++ b/snapfaas/bins/sffs/main.rs
@@ -167,9 +167,6 @@ fn main() {
                 Err(labeled_fs::Error::BadTargetLabel) => {
                     eprintln!("Bad target label.");
                 },
-                Err(labeled_fs::Error::UidCollision) => {
-                    eprintln!("Uid collision");
-                }
                 Ok(()) => {},
             }
         },
@@ -192,9 +189,6 @@ fn main() {
                 Err(labeled_fs::Error::BadTargetLabel) => {
                     eprintln!("Bad target label.");
                 },
-                Err(labeled_fs::Error::UidCollision) => {
-                    eprintln!("Uid collision");
-                }
                 Ok(()) => {},
             }
         },
@@ -215,7 +209,7 @@ fn main() {
                 Err(labeled_fs::Error::Unauthorized) => {
                     eprintln!("Bad endorsement.");
                 },
-                Err(labeled_fs::Error::BadTargetLabel) | Err(labeled_fs::Error::UidCollision) => {
+                Err(labeled_fs::Error::BadTargetLabel) => {
                     eprintln!("write should not reach here.");
                 },
                 Ok(()) => {},

--- a/snapfaas/bins/sffs/main.rs
+++ b/snapfaas/bins/sffs/main.rs
@@ -42,7 +42,9 @@ fn main() {
     let cmd_arguments = App::new("sffs")
         .version(crate_version!())
         .author(crate_authors!())
-        .about("a wrapper over the labeled_fs module.")
+        .about("This program is a wrapper over the labeled_fs module. \
+            The main goal is to serve as a tool to create and modify files in the file system. \
+            The program outputs reads to any requested path to the stdin.")
         .subcommand(
             SubCommand::with_name("ls")
                 .about("List the given directory")
@@ -162,6 +164,12 @@ fn main() {
                 Err(labeled_fs::Error::Unauthorized) => {
                     eprintln!("Bad endorsement.");
                 },
+                Err(labeled_fs::Error::BadTargetLabel) => {
+                    eprintln!("Bad target label.");
+                },
+                Err(labeled_fs::Error::UidCollision) => {
+                    eprintln!("Uid collision");
+                }
                 Ok(()) => {},
             }
         },
@@ -181,6 +189,12 @@ fn main() {
                 Err(labeled_fs::Error::Unauthorized) => {
                     eprintln!("Bad endorsement.");
                 },
+                Err(labeled_fs::Error::BadTargetLabel) => {
+                    eprintln!("Bad target label.");
+                },
+                Err(labeled_fs::Error::UidCollision) => {
+                    eprintln!("Uid collision");
+                }
                 Ok(()) => {},
             }
         },
@@ -200,6 +214,9 @@ fn main() {
                 },
                 Err(labeled_fs::Error::Unauthorized) => {
                     eprintln!("Bad endorsement.");
+                },
+                Err(labeled_fs::Error::BadTargetLabel) | Err(labeled_fs::Error::UidCollision) => {
+                    eprintln!("write should not reach here.");
                 },
                 Ok(()) => {},
             }

--- a/snapfaas/bins/sffs/main.rs
+++ b/snapfaas/bins/sffs/main.rs
@@ -1,0 +1,211 @@
+#[macro_use(crate_version, crate_authors)]
+extern crate clap;
+use clap::{App, Arg, SubCommand};
+use labeled::dclabel::{self, DCLabel};
+use std::io::{Read, Write};
+
+use snapfaas::labeled_fs;
+
+fn input_to_dclabel(si_clauses: [Vec<&str>; 2]) -> DCLabel {
+    let mut components = Vec::new();
+    for clauses in si_clauses {
+        let component: dclabel::Component = if clauses[0].to_lowercase() == "true" {
+            true.into()
+        } else if clauses[0].to_lowercase() == "false" {
+            false.into()
+        } else {
+            let mut s_vec = Vec::new();
+            for clause in clauses {
+                let c: Vec<String> = clause.split(",").map(|s| s.to_lowercase()).collect();
+                s_vec.push(c);
+            }
+            s_vec.into()
+        };
+        components.push(component);
+    }
+    let secrecy = components.remove(0);
+    let integrity = components.remove(0);
+    DCLabel::new(secrecy, integrity)
+}
+
+fn input_to_endorsement(endorse: &str) -> DCLabel {
+    if endorse.to_lowercase() == "false" {
+        DCLabel::new(true, false)
+    } else if endorse.to_lowercase() == "true" {
+        DCLabel::new(true, true)
+    } else {
+        DCLabel::new(true, [[endorse.to_lowercase()]])
+    }
+}
+
+fn main() {
+    let cmd_arguments = App::new("sffs")
+        .version(crate_version!())
+        .author(crate_authors!())
+        .about("a wrapper over the labeled_fs module.")
+        .subcommand(
+            SubCommand::with_name("ls")
+                .about("List the given directory")
+                .arg(Arg::with_name("PATH").index(1).required(true))
+        )
+        .subcommand(
+            SubCommand::with_name("cat")
+                .about("Ouput the given file to the stdout")
+                .arg(Arg::with_name("PATH").index(1).required(true))
+        )
+        .subcommand(
+            SubCommand::with_name("mkdir")
+                .about("Create a directory named by the given path with the given label")
+                .arg(Arg::with_name("PATH").index(1).required(true))
+                .arg(Arg::with_name("secrecy")
+                    .short("s")
+                    .long("secrecy")
+                    .multiple(true)
+                    .value_delimiter(";")
+                    .require_delimiter(true)
+                    .value_name("SECRECY CLAUSE")
+                    .required(true)
+                    .help("A DCLabel clause is a string of comma-delimited principals. Multiple clauses must be delimited by semi-colons."))
+                .arg(Arg::with_name("integrity")
+                    .short("i")
+                    .long("integrity")
+                    .multiple(true)
+                    .value_delimiter(";")
+                    .require_delimiter(true)
+                    .value_name("INTEGRITY CLAUSE")
+                    .required(true)
+                    .help("A DCLabel clause is a string of comma-delimited principals. Multiple clauses must be delimited by semi-colons."))
+                .arg(Arg::with_name("endorse")
+                    .short("e")
+                    .long("endorse")
+                    .required(true)
+                    .takes_value(true)
+                    .help("Endorse the creation with the given principal"))
+        )
+        .subcommand(
+            SubCommand::with_name("mkfile")
+                .about("Create a file named by the given path with the given label")
+                .arg(Arg::with_name("PATH").index(1).required(true))
+                .arg(Arg::with_name("secrecy")
+                    .short("s")
+                    .long("secrecy")
+                    .multiple(true)
+                    .value_delimiter(";")
+                    .require_delimiter(true)
+                    .value_name("SECRECY CLAUSE")
+                    .required(true)
+                    .help("A DCLabel clause is a string of comma-delimited principals. Multiple clauses must be delimited by semi-colons."))
+                .arg(Arg::with_name("integrity")
+                    .short("i")
+                    .long("integrity")
+                    .multiple(true)
+                    .value_delimiter(";")
+                    .require_delimiter(true)
+                    .value_name("INTEGRITY CLAUSE")
+                    .required(true)
+                    .help("A DCLabel clause is a string of comma-delimited principals. Multiple clauses must be delimited by semi-colons."))
+                .arg(Arg::with_name("endorse")
+                    .short("e")
+                    .long("endorse")
+                    .required(true)
+                    .takes_value(true)
+                    .help("Endorse the creation with the given principal"))
+        )
+        .subcommand(
+            SubCommand::with_name("write")
+                .about("Overwrite the given file with the data from the given file or the stdin")
+                .arg(Arg::with_name("PATH").index(1).required(true))
+                .arg(Arg::with_name("FILE")
+                    .short("f")
+                    .long("file")
+                    .takes_value(true)
+                    .value_name("FILE"))
+                .arg(Arg::with_name("endorse")
+                    .short("e")
+                    .long("endorse")
+                    .required(true)
+                    .takes_value(true)
+                    .help("Endorse the modification with the given principal"))
+        )
+        .get_matches();
+
+    let mut cur_label = DCLabel::public();
+    match cmd_arguments.subcommand() {
+        ("cat", Some(sub_m)) => {
+            if let Ok(data) = labeled_fs::read(sub_m.value_of("PATH").unwrap(), &mut cur_label) {
+                std::io::stdout().write_all(&data).unwrap();
+            } else {
+                eprintln!("Invalid path.");
+            }
+        },
+        ("ls", Some(sub_m)) => {
+            if let Ok(list) = labeled_fs::list(sub_m.value_of("PATH").unwrap(), &mut cur_label) {
+                let output = list.join("\t");
+                println!("{}", output);
+            } else {
+                eprintln!("Invalid path.");
+            }
+        },
+        ("mkdir", Some(sub_m)) => {
+            let path = std::path::Path::new(sub_m.value_of("PATH").unwrap());
+            let s_clauses: Vec<&str> = sub_m.values_of("secrecy").unwrap().collect();
+            let i_clauses: Vec<&str> = sub_m.values_of("integrity").unwrap().collect();
+            cur_label = input_to_endorsement(sub_m.value_of("endorse").unwrap());
+            match labeled_fs::create_dir(
+                path.parent().unwrap().to_str().unwrap(),
+                path.file_name().unwrap().to_str().unwrap(),
+                input_to_dclabel([s_clauses, i_clauses]),
+                &mut cur_label) {
+                Err(labeled_fs::Error::BadPath) => {
+                    eprintln!("Invalid path.");
+                },
+                Err(labeled_fs::Error::Unauthorized) => {
+                    eprintln!("Bad endorsement.");
+                },
+                Ok(()) => {},
+            }
+        },
+        ("mkfile", Some(sub_m)) => {
+            let path = std::path::Path::new(sub_m.value_of("PATH").unwrap());
+            let s_clauses: Vec<&str> = sub_m.values_of("secrecy").unwrap().collect();
+            let i_clauses: Vec<&str> = sub_m.values_of("integrity").unwrap().collect();
+            cur_label = input_to_endorsement(sub_m.value_of("endorse").unwrap());
+            match labeled_fs::create_file(
+                path.parent().unwrap().to_str().unwrap(),
+                path.file_name().unwrap().to_str().unwrap(),
+                input_to_dclabel([s_clauses, i_clauses]),
+                &mut cur_label) {
+                Err(labeled_fs::Error::BadPath) => {
+                    eprintln!("Invalid path.");
+                },
+                Err(labeled_fs::Error::Unauthorized) => {
+                    eprintln!("Bad endorsement.");
+                },
+                Ok(()) => {},
+            }
+        },
+        ("write", Some(sub_m)) => {
+            let data = sub_m.value_of("FILE").map_or_else(
+                || {
+                    let mut buf = Vec::new();
+                    std::io::stdin().read_to_end(&mut buf).unwrap();
+                    buf
+                },
+                |p| std::fs::read(p).unwrap()
+            );
+            cur_label = input_to_endorsement(sub_m.value_of("endorse").unwrap());
+            match labeled_fs::write(sub_m.value_of("PATH").unwrap(), data, &mut cur_label) {
+                Err(labeled_fs::Error::BadPath) => {
+                    eprintln!("Invalid path.");
+                },
+                Err(labeled_fs::Error::Unauthorized) => {
+                    eprintln!("Bad endorsement.");
+                },
+                Ok(()) => {},
+            }
+        },
+        (&_, _) => {
+            eprintln!("{}", cmd_arguments.usage());
+        }
+    }
+}

--- a/snapfaas/src/labeled_fs/dir.rs
+++ b/snapfaas/src/labeled_fs/dir.rs
@@ -29,12 +29,19 @@ impl Directory {
         self.mappings.get(name).ok_or(Error::BadPath)
     }
 
-    pub fn create(&mut self, name: &str, cur_label: &DCLabel, entry_type: DirEntry, label: DCLabel) -> Result<u64> {
+    pub fn create(
+        &mut self,
+        name: &str,
+        cur_label: &DCLabel,
+        entry_type: DirEntry,
+        label: DCLabel,
+        uid: u64
+    ) -> Result<u64> {
         if cur_label.can_flow_to(&label) {
             if let Some(_) = self.mappings.get(name) {
                 Err(Error::BadPath)
             } else {
-                let new_entry = LabeledDirEntry::new(label, entry_type);
+                let new_entry = LabeledDirEntry::new(label, entry_type, uid);
                 let uid = new_entry.uid();
                 let _ = self.mappings.insert(name.to_string(), new_entry);
                 Ok(uid)

--- a/snapfaas/src/labeled_fs/dir.rs
+++ b/snapfaas/src/labeled_fs/dir.rs
@@ -40,7 +40,7 @@ impl Directory {
                 Ok(uid)
             }
         } else {
-            Err(Error::Unauthorized)
+            Err(Error::BadTargetLabel)
         }
     }
 

--- a/snapfaas/src/labeled_fs/direntry.rs
+++ b/snapfaas/src/labeled_fs/direntry.rs
@@ -18,8 +18,8 @@ pub struct LabeledDirEntry {
 }
 
 impl LabeledDirEntry {
-    pub fn new(label: DCLabel, entry_type: DirEntry) -> Self {
-        Self { label, entry_type, uid: super::get_uid() }
+    pub fn new(label: DCLabel, entry_type: DirEntry, uid: u64) -> Self {
+        Self { label, entry_type, uid }
     }
 
     pub fn root() -> Self {

--- a/snapfaas/src/labeled_fs/direntry.rs
+++ b/snapfaas/src/labeled_fs/direntry.rs
@@ -19,7 +19,7 @@ pub struct LabeledDirEntry {
 
 impl LabeledDirEntry {
     pub fn new(label: DCLabel, entry_type: DirEntry) -> Self {
-        Self { label, entry_type, uid: super::get_next_uid() }
+        Self { label, entry_type, uid: super::get_uid() }
     }
 
     pub fn root() -> Self {
@@ -34,8 +34,7 @@ impl LabeledDirEntry {
         &self
     }
 
-    /// First read and raise label if needed, then apply privilege to check if write can happen.
-    /// This function always updates `cur_label` to privilege applied.
+    /// First read and raise label if needed then check if the writer can write
     pub fn unlabel_write_check(&self, cur_label: &mut DCLabel) -> Result<&Self> {
         // write implies read
         if !self.label.can_flow_to(cur_label) {

--- a/snapfaas/src/labeled_fs/mod.rs
+++ b/snapfaas/src/labeled_fs/mod.rs
@@ -22,6 +22,10 @@ lazy_static::lazy_static! {
             .open(std::path::Path::new("storage"))
             .unwrap();
 
+        // Create the root directory object at key 0 if not already exists.
+        // `put_val_db_no_overwrite` uses `NO_OVERWRITE` as the write flag to make sure that it
+        // will be a noop if the root already exists at key 0. And we can safely ignore the
+        // returned `Result` here which if an error is an KeyExist error.
         let default_db = dbenv.open_db(None).unwrap();
         let mut txn = dbenv.begin_rw_txn().unwrap();
         let root_uid = 0;


### PR DESCRIPTION
Two main changes:
1. `sffs` binary, a command-line tool to read files and directories, create files and directories, and write files in the labeled file system. Respectively, the subcommands are `cat`, `ls`, `mkdir`, `mkfile`, `write`.

2. Addtionally, one main change to the existing `labeled_fs` module.
The module now uses random generated `uid`s instead of continuously incremented `uid`s.
Random generated `uid`s remove the need of persisting `next_uid`.