### PR TITLE
Remove socket files before creation

### DIFF
--- a/snapfaas/bins/firerunner/main.rs
+++ b/snapfaas/bins/firerunner/main.rs
@@ -372,10 +372,12 @@ fn main() {
     }
 
     if let Some(cid) = cid.clone() {
+        let vsock_path = format!("worker-{}.sock", cid);
+        let _ = std::fs::remove_file(&vsock_path);
         let vsock_config = VsockDeviceConfig {
             vsock_id: "vsock0".to_string(),
             guest_cid: cid,
-            uds_path: format!("worker-{}.sock", cid).to_string(),
+            uds_path: vsock_path.to_string(),
         };
         if let Err(e) = vmm.add_vsock(vsock_config) {
             eprintln!("Vmm failed to add vsock due to: {:?}", e);

--- a/snapfaas/bins/singlevm/main.rs
+++ b/snapfaas/bins/singlevm/main.rs
@@ -224,6 +224,7 @@ fn main() {
     let t1 = Instant::now();
     let mut vm =  Vm::new(id, firerunner, "myapp".to_string(), vm_app_config, allow_network);
     let vm_listener_path = format!("worker-{}.sock_1234", CID);
+    let _ = std::fs::remove_file(&vm_listener_path);
     let vm_listener = UnixListener::bind(vm_listener_path).expect("Failed to bind to unix listener");
     let force_exit = cmd_arguments.is_present("force_exit");
     if let Err(e) = vm.launch(None, vm_listener, CID, force_exit, Some(odirect)) {

--- a/snapfaas/src/worker.rs
+++ b/snapfaas/src/worker.rs
@@ -41,7 +41,9 @@ impl Worker {
             let mut stat = metrics::WorkerMetrics::new(log_file);
             stat.start_timed_flush(FLUSH_INTERVAL_SECS);
 
-            let vm_listener = match UnixListener::bind(format!("worker-{}.sock_1234", cid)) {
+            let vm_listener_path = format!("worker-{}.sock_1234", cid);
+            let _ = std::fs::remove_file(&vm_listener_path);
+            let vm_listener = match UnixListener::bind(vm_listener_path) {
                 Ok(listener) => listener,
                 Err(e) => panic!("Failed to bind to unix listener \"worker-{}.sock_1234\": {:?}", cid, e),
             };


### PR DESCRIPTION
In case there are left-over socket files from a previous run, always
attempt to remove a socket file before creating it.